### PR TITLE
change: update default PHP version to `8.1`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,14 +26,14 @@ jobs:
       phpunit: true
       phpunit_suite: app/tests/
       # phpunit_config_file:
-      phpunit_php_version: '7.4'
+      phpunit_php_version: '8.1'
       phpstan: true
       phpstan_dir: app/src/
-      phpstan_php_version: '7.4'
+      phpstan_php_version: '8.1'
       phpcs: true
       phpcs_dir: app/
       # behat: false
-      # behat_php_version: '7.4'
+      # behat_php_version: '8.1'
   # ----------------------
   #   Client
   # ----------------------

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     "config": {
         "process-timeout": 600,
         "platform": {
-             "php": "7.4",
+             "php": "8.1",
              "ext-intl": "1.0.0"
         }
     },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "browserslist": [
     "extends @syntro-opensource/browserslist-config-base"
   ],
+  "ssdev": {
+    "image-host": "syntrocontainer/silverstripe-dev:8.1-apache-buster"
+  },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@syntro-opensource/browserslist-config-base": "^1.0.0",


### PR DESCRIPTION
With the release of Silverstripe 4.11 we get php 8.1 support. Time to update!